### PR TITLE
Added std::filesystem support for Clang and AppleClang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.imgui.ini
+
+# JetBrain's Clion caches and temps files
+.idea/
+cmake-build-debug/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,11 +72,10 @@ set(
     glfw
 )
 
+set(CXXFLAGS ${CXXFLAGS} std=c++14)
 if (GLMLV_USE_BOOST_FILESYSTEM)
     set(LIBRARIES ${LIBRARIES} ${Boost_SYSTEM_LIBRARY} ${Boost_FILESYSTEM_LIBRARY})
-else()
-    set(CXXFLAGS ${CXXFLAGS} std=c++14)
-    
+else()    
     if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
         set(CXXFLAGS ${CXXFLAGS} std=c++17)
         set(LIBRARIES ${LIBRARIES} stdc++fs)
@@ -106,7 +105,7 @@ foreach(DIR ${APP_DIRECTORIES})
         SRC_FILES
         apps/${APP}/*.cpp apps/${APP}/*.hpp apps/${APP}/*.glsl apps/${APP}/assets/*
     )
-
+    
     add_executable(
         ${APP}
         ${SRC_FILES}
@@ -154,8 +153,13 @@ foreach(DIR ${APP_DIRECTORIES})
         IMGUI_IMPL_OPENGL_LOADER_GLAD
         GLM_ENABLE_EXPERIMENTAL
     )
-
-    set_property(TARGET ${APP} PROPERTY CXX_STANDARD 17)
+    
+    if(${CMAKE_VERSION} VERSION_LESS "3.8.0")
+        set_property(TARGET ${APP} PROPERTY CXX_STANDARD 14)
+    else()
+        set_property(TARGET ${APP} PROPERTY CXX_STANDARD 17)
+    endif()
+        
 
     target_link_libraries(
         ${APP}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
+
 cmake_policy(SET CMP0048 NEW)
 
 project(gltf-viewer-tutorial VERSION 0.0.1)
-
-if(CMAKE_COMPILER_IS_GNUCXX)
-    add_definitions(
-        -std=c++14
-    )
-endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
@@ -26,6 +21,11 @@ option(GLFW_BUILD_TESTS OFF)
 option(GLFW_BUILD_EXAMPLES OFF)
 add_subdirectory(third-party/${GLFW_DIR})
 
+if(${CMAKE_VERSION} VERSION_LESS "3.10.0")
+    set(OpenGL_GL_PREFERENCE LEGACY)
+else()
+    set(OpenGL_GL_PREFERENCE GLVND)
+endif()
 find_package(OpenGL REQUIRED)
 
 if(GLMLV_USE_BOOST_FILESYSTEM)
@@ -72,15 +72,29 @@ set(
     glfw
 )
 
-if(CMAKE_COMPILER_IS_GNUCXX AND NOT GLMLV_USE_BOOST_FILESYSTEM)
-    set(LIBRARIES ${LIBRARIES} stdc++fs)
-endif()
-
 if (GLMLV_USE_BOOST_FILESYSTEM)
     set(LIBRARIES ${LIBRARIES} ${Boost_SYSTEM_LIBRARY} ${Boost_FILESYSTEM_LIBRARY})
+else()
+    set(CXXFLAGS ${CXXFLAGS} std=c++14)
+    
+    if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        set(CXXFLAGS ${CXXFLAGS} std=c++17)
+        set(LIBRARIES ${LIBRARIES} stdc++fs)
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "8.0.0")
+            set(USE_STD_FILESYSTEM 1)
+        endif()
+    
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang")
+        if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0.0")
+            set(LIBRARIES ${LIBRARIES} stdc++fs)
+        else()
+            set(CXXFLAGS ${CXXFLAGS} std=c++17)
+            set(USE_STD_FILESYSTEM 1)
+        endif()
+    endif()
 endif()
 
-source_group ("glsl" REGULAR_EXPRESSION "*/*.glsl")
+source_group ("glsl" REGULAR_EXPRESSION ".*/*.glsl")
 source_group ("third-party" REGULAR_EXPRESSION "third-party/*.*")
 
 file(GLOB APP_DIRECTORIES "apps/*")
@@ -98,7 +112,14 @@ foreach(DIR ${APP_DIRECTORIES})
         ${SRC_FILES}
         ${THIRD_PARTY_SRC_FILES}
     )
-
+    
+    if (USE_STD_FILESYSTEM)
+        target_compile_definitions(
+            ${APP}
+            PUBLIC
+            USE_STD_FILESYSTEM
+        )
+    endif()
     if(GLMLV_USE_BOOST_FILESYSTEM)
         target_include_directories (
             ${APP}

--- a/apps/gltf-viewer/utils/filesystem.hpp
+++ b/apps/gltf-viewer/utils/filesystem.hpp
@@ -5,7 +5,6 @@
 #else
 #ifdef _MSC_VER
 #if _MSC_VER >= 1923
-#include <filesystem>
 #define USE_STD_FILESYSTEM 1
 #else
 #include <experimental/filesystem>
@@ -19,6 +18,7 @@
 namespace fs = boost::filesystem;
 #else
 #ifdef USE_STD_FILESYSTEM
+#include <filesystem>
 namespace fs = std::filesystem; // Shorter namespace for experimental
                                 // filesystem standard library
 #else


### PR DESCRIPTION
* Set `OpenGL_GL_PREFERENCE` according to [CMP0072](https://cmake.org/cmake/help/git-stage/policy/CMP0072.html)

*  Fixed the regex in `source_group("glsl" REGULAR_EXPRESSION "*/*.glsl")` which was not compiling:

```bash
RegularExpression::compile(): ?+* follows nothing.
RegularExpression::compile(): Error in compile.
```

* Set `std=c++14` or `std=c++17` only for `CXX` to avoid warning on *gcc* and error on *clang* when compiling *glfw*.

* Fixed  problems of `std::filesystem` and `std::experimental::filesystem` on *clang* and newer version of *g++* by defining (or not) the macro `USE_STD_FILESYSTEM`.


### Tested with :

* `gcc/g++`:
    * `9.2.0` (use `std::filesystem`)
    * `8.3.0` (use `std::filesystem`)
    * `7.5.0` (use `std::experimental::filesystem`)
    * `6.5.0` (use `std::experimental::filesystem`)

* `clang/clang++`:
    * `9.0.1` (use `std::filesystem`)
    * `7.0.1` (use `std::experimental::filesystem`)

I can't test it with *MSVC* on my computer.

Since students seems to use different OS / compilers, automatizing these tests with a service like [travis-ci](https://travis-ci.com/) could be useful.

Logs of different versions below.


### gcc/g++ 9.2.0

```bash
23:02:38 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ CXX=/usr/bin/c++ CC=/usr/bin/gcc cmake ..
-- The C compiler identification is GNU 9.2.0
-- The CXX compiler identification is GNU 9.2.0
-- Check for working C compiler: /usr/bin/gcc
-- Check for working C compiler: /usr/bin/gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Using X11 for window creation
-- Found X11: /usr/include
-- Looking for XOpenDisplay in /usr/lib/libX11.so;/usr/lib/libXext.so
-- Looking for XOpenDisplay in /usr/lib/libX11.so;/usr/lib/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
-- Found OpenGL: /usr/lib/libOpenGL.so
-- Configuring done
-- Generating done
-- Build files have been written to: /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug

23:02:49 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ make
Scanning dependencies of target glfw
[  2%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/context.c.o
[  5%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/init.c.o
[  8%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/input.c.o
[ 11%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/monitor.c.o
[ 14%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/vulkan.c.o
[ 17%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/window.c.o
[ 20%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_init.c.o
[ 22%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_monitor.c.o
[ 25%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_window.c.o
[ 28%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/xkb_unicode.c.o
[ 31%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/posix_time.c.o
[ 34%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/posix_thread.c.o
[ 37%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/glx_context.c.o
[ 40%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/egl_context.c.o
[ 42%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/osmesa_context.c.o
[ 45%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/linux_joystick.c.o
[ 48%] Linking C static library libglfw3.a
[ 48%] Built target glfw
[ 51%] Generating bin/shaders/gltf-viewer/normals.fs.glsl
[ 54%] Generating bin/shaders/gltf-viewer/forward.vs.glsl
[ 57%] Generating bin/shaders/gltf-viewer/magenta.fs.glsl
Scanning dependencies of target gltf-viewer
[ 60%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/ViewerApplication.cpp.o
[ 62%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/main.cpp.o
[ 65%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/tiny_gltf_impl.cpp.o
[ 68%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/cameras.cpp.o
[ 71%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/gl_debug_output.cpp.o
[ 74%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/gltf.cpp.o
[ 77%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/images.cpp.o
[ 80%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui.cpp.o
[ 82%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_demo.cpp.o
[ 85%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_draw.cpp.o
[ 88%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_widgets.cpp.o
[ 91%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/examples/imgui_impl_opengl3.cpp.o
[ 94%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/examples/imgui_impl_glfw.cpp.o
[ 97%] Building C object CMakeFiles/gltf-viewer.dir/third-party/glad/src/glad.c.o
[100%] Linking CXX executable bin/gltf-viewer
[100%] Built target gltf-viewer

23:04:03 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ ./bin/gltf-viewer info
OpenGL Version 4.4
```


### gcc/g++ 8.3.0

```bash
23:07:03 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ CXX=/usr/bin/c++-8 CC=/usr/bin/gcc-8 cmake ..
-- The C compiler identification is GNU 8.3.0
-- The CXX compiler identification is GNU 8.3.0
-- Check for working C compiler: /usr/bin/gcc-8
-- Check for working C compiler: /usr/bin/gcc-8 -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++-8
-- Check for working CXX compiler: /usr/bin/c++-8 -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Using X11 for window creation
-- Found X11: /usr/include
-- Looking for XOpenDisplay in /usr/lib/libX11.so;/usr/lib/libXext.so
-- Looking for XOpenDisplay in /usr/lib/libX11.so;/usr/lib/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
-- Found OpenGL: /usr/lib/libOpenGL.so
-- Configuring done
-- Generating done
-- Build files have been written to: /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug

23:07:39 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ make
-- Using X11 for window creation
-- Configuring done
-- Generating done
-- Build files have been written to: /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug
Scanning dependencies of target glfw
[  2%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/context.c.o
[  5%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/init.c.o
[  8%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/input.c.o
[ 11%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/monitor.c.o
[ 14%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/vulkan.c.o
[ 17%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/window.c.o
[ 20%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_init.c.o
[ 22%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_monitor.c.o
[ 25%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_window.c.o
[ 28%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/xkb_unicode.c.o
[ 31%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/posix_time.c.o
[ 34%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/posix_thread.c.o
[ 37%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/glx_context.c.o
[ 40%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/egl_context.c.o
[ 42%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/osmesa_context.c.o
[ 45%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/linux_joystick.c.o
[ 48%] Linking C static library libglfw3.a
[ 48%] Built target glfw
[ 51%] Generating bin/shaders/gltf-viewer/normals.fs.glsl
[ 54%] Generating bin/shaders/gltf-viewer/forward.vs.glsl
[ 57%] Generating bin/shaders/gltf-viewer/magenta.fs.glsl
Scanning dependencies of target gltf-viewer
[ 60%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/ViewerApplication.cpp.o
[ 62%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/main.cpp.o
[ 65%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/tiny_gltf_impl.cpp.o
[ 68%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/cameras.cpp.o
[ 71%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/gl_debug_output.cpp.o
[ 74%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/gltf.cpp.o
[ 77%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/images.cpp.o
[ 80%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui.cpp.o
[ 82%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_demo.cpp.o
[ 85%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_draw.cpp.o
[ 88%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_widgets.cpp.o
[ 91%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/examples/imgui_impl_opengl3.cpp.o
[ 94%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/examples/imgui_impl_glfw.cpp.o
[ 97%] Building C object CMakeFiles/gltf-viewer.dir/third-party/glad/src/glad.c.o
[100%] Linking CXX executable bin/gltf-viewer
[100%] Built target gltf-viewer

23:09:41 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ ./bin/gltf-viewer info
OpenGL Version 4.4
```

### gcc/g++ 7.5.0

```bash
23:22:00 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ CXX=/usr/bin/c++-7 CC=/usr/bin/gcc-7 cmake ..
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is GNU 7.5.0
-- Check for working C compiler: /usr/bin/gcc-7
-- Check for working C compiler: /usr/bin/gcc-7 -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++-7
-- Check for working CXX compiler: /usr/bin/c++-7 -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Using X11 for window creation
-- Found X11: /usr/include
-- Looking for XOpenDisplay in /usr/lib/libX11.so;/usr/lib/libXext.so
-- Looking for XOpenDisplay in /usr/lib/libX11.so;/usr/lib/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
-- Found OpenGL: /usr/lib/libOpenGL.so
-- Configuring done
-- Generating done
-- Build files have been written to: /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug

23:22:12 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ make
Scanning dependencies of target glfw
[  2%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/context.c.o
[  5%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/init.c.o
[  8%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/input.c.o
[ 11%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/monitor.c.o
[ 14%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/vulkan.c.o
[ 17%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/window.c.o
[ 20%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_init.c.o
[ 22%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_monitor.c.o
[ 25%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_window.c.o
[ 28%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/xkb_unicode.c.o
[ 31%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/posix_time.c.o
[ 34%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/posix_thread.c.o
[ 37%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/glx_context.c.o
[ 40%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/egl_context.c.o
[ 42%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/osmesa_context.c.o
[ 45%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/linux_joystick.c.o
[ 48%] Linking C static library libglfw3.a
[ 48%] Built target glfw
[ 51%] Generating bin/shaders/gltf-viewer/normals.fs.glsl
[ 54%] Generating bin/shaders/gltf-viewer/forward.vs.glsl
[ 57%] Generating bin/shaders/gltf-viewer/magenta.fs.glsl
Scanning dependencies of target gltf-viewer
[ 60%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/ViewerApplication.cpp.o
[ 62%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/main.cpp.o
[ 65%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/tiny_gltf_impl.cpp.o
[ 68%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/cameras.cpp.o
[ 71%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/gl_debug_output.cpp.o
[ 74%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/gltf.cpp.o
[ 77%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/images.cpp.o
[ 80%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui.cpp.o
[ 82%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_demo.cpp.o
[ 85%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_draw.cpp.o
[ 88%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_widgets.cpp.o
[ 91%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/examples/imgui_impl_opengl3.cpp.o
[ 94%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/examples/imgui_impl_glfw.cpp.o
[ 97%] Building C object CMakeFiles/gltf-viewer.dir/third-party/glad/src/glad.c.o
[100%] Linking CXX executable bin/gltf-viewer
[100%] Built target gltf-viewer

23:22:44 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ ./bin/gltf-viewer info
OpenGL Version 4.4
```

### gcc/g++ 6.5.0

```bash
23:48:03 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ CXX=/usr/bin/c++-6 CC=/usr/bin/gcc-6 cmake ..
-- The C compiler identification is GNU 6.5.0
-- The CXX compiler identification is GNU 6.5.0
-- Check for working C compiler: /usr/bin/gcc-6
-- Check for working C compiler: /usr/bin/gcc-6 -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++-6
-- Check for working CXX compiler: /usr/bin/c++-6 -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Using X11 for window creation
-- Found X11: /usr/include
-- Looking for XOpenDisplay in /usr/lib/libX11.so;/usr/lib/libXext.so
-- Looking for XOpenDisplay in /usr/lib/libX11.so;/usr/lib/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
-- Found OpenGL: /usr/lib/libOpenGL.so
-- Configuring done
-- Generating done
-- Build files have been written to: /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug

23:48:15 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ make
Scanning dependencies of target glfw
[  2%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/context.c.o
[  5%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/init.c.o
[  8%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/input.c.o
[ 11%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/monitor.c.o
[ 14%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/vulkan.c.o
[ 17%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/window.c.o
[ 20%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_init.c.o
[ 22%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_monitor.c.o
[ 25%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_window.c.o
[ 28%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/xkb_unicode.c.o
[ 31%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/posix_time.c.o
[ 34%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/posix_thread.c.o
[ 37%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/glx_context.c.o
[ 40%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/egl_context.c.o
[ 42%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/osmesa_context.c.o
[ 45%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/linux_joystick.c.o
[ 48%] Linking C static library libglfw3.a
[ 48%] Built target glfw
[ 51%] Generating bin/shaders/gltf-viewer/normals.fs.glsl
[ 54%] Generating bin/shaders/gltf-viewer/forward.vs.glsl
[ 57%] Generating bin/shaders/gltf-viewer/magenta.fs.glsl
Scanning dependencies of target gltf-viewer
[ 60%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/ViewerApplication.cpp.o
[ 62%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/main.cpp.o
[ 65%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/tiny_gltf_impl.cpp.o
[ 68%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/cameras.cpp.o
[ 71%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/gl_debug_output.cpp.o
[ 74%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/gltf.cpp.o
[ 77%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/images.cpp.o
[ 80%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui.cpp.o
[ 82%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_demo.cpp.o
[ 85%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_draw.cpp.o
[ 88%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_widgets.cpp.o
[ 91%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/examples/imgui_impl_opengl3.cpp.o
[ 94%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/examples/imgui_impl_glfw.cpp.o
[ 97%] Building C object CMakeFiles/gltf-viewer.dir/third-party/glad/src/glad.c.o
[100%] Linking CXX executable bin/gltf-viewer
[100%] Built target gltf-viewer

23:48:59 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ ./bin/gltf-viewer info
OpenGL Version 4.4
```



### clang/clang++ 9.0.1

```bash
23:29:53 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ CXX=/usr/bin/clang++ CC=/usr/bin/clang cmake ..
-- The C compiler identification is Clang 9.0.1
-- The CXX compiler identification is Clang 9.0.1
-- Check for working C compiler: /usr/bin/clang
-- Check for working C compiler: /usr/bin/clang -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/clang++
-- Check for working CXX compiler: /usr/bin/clang++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Using X11 for window creation
-- Found X11: /usr/include
-- Looking for XOpenDisplay in /usr/lib/libX11.so;/usr/lib/libXext.so
-- Looking for XOpenDisplay in /usr/lib/libX11.so;/usr/lib/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
-- Found OpenGL: /usr/lib/libOpenGL.so
-- Configuring done
-- Generating done
-- Build files have been written to: /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug

23:30:11 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ make
Scanning dependencies of target glfw
[  2%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/context.c.o
[  5%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/init.c.o
[  8%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/input.c.o
[ 11%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/monitor.c.o
[ 14%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/vulkan.c.o
[ 17%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/window.c.o
[ 20%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_init.c.o
[ 22%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_monitor.c.o
[ 25%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_window.c.o
[ 28%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/xkb_unicode.c.o
[ 31%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/posix_time.c.o
[ 34%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/posix_thread.c.o
[ 37%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/glx_context.c.o
[ 40%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/egl_context.c.o
[ 42%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/osmesa_context.c.o
[ 45%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/linux_joystick.c.o
[ 48%] Linking C static library libglfw3.a
[ 48%] Built target glfw
[ 51%] Generating bin/shaders/gltf-viewer/normals.fs.glsl
[ 54%] Generating bin/shaders/gltf-viewer/forward.vs.glsl
[ 57%] Generating bin/shaders/gltf-viewer/magenta.fs.glsl
Scanning dependencies of target gltf-viewer
[ 60%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/ViewerApplication.cpp.o
[ 62%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/main.cpp.o
[ 65%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/tiny_gltf_impl.cpp.o
[ 68%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/cameras.cpp.o
[ 71%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/gl_debug_output.cpp.o
[ 74%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/gltf.cpp.o
[ 77%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/images.cpp.o
[ 80%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui.cpp.o
[ 82%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_demo.cpp.o
[ 85%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_draw.cpp.o
[ 88%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_widgets.cpp.o
[ 91%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/examples/imgui_impl_opengl3.cpp.o
[ 94%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/examples/imgui_impl_glfw.cpp.o
[ 97%] Building C object CMakeFiles/gltf-viewer.dir/third-party/glad/src/glad.c.o
[100%] Linking CXX executable bin/gltf-viewer
[100%] Built target gltf-viewer

23:32:03 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ ./bin/gltf-viewer info
OpenGL Version 4.4
```


### clang/clang++ 7.0.1

```bash
23:42:41 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ CXX=/usr/bin/clang++-7 CC=/usr/bin/clang-7 cmake ..
-- The C compiler identification is Clang 7.0.1
-- The CXX compiler identification is Clang 7.0.1
-- Check for working C compiler: /usr/bin/clang-7
-- Check for working C compiler: /usr/bin/clang-7 -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/clang++-7
-- Check for working CXX compiler: /usr/bin/clang++-7 -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Using X11 for window creation
-- Found X11: /usr/include
-- Looking for XOpenDisplay in /usr/lib/libX11.so;/usr/lib/libXext.so
-- Looking for XOpenDisplay in /usr/lib/libX11.so;/usr/lib/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
-- Found OpenGL: /usr/lib/libOpenGL.so
-- Configuring done
-- Generating done
-- Build files have been written to: /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug

23:42:54 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ make
Scanning dependencies of target glfw
[  2%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/context.c.o
[  5%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/init.c.o
[  8%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/input.c.o
[ 11%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/monitor.c.o
[ 14%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/vulkan.c.o
[ 17%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/window.c.o
[ 20%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_init.c.o
[ 22%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_monitor.c.o
[ 25%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/x11_window.c.o
[ 28%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/xkb_unicode.c.o
[ 31%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/posix_time.c.o
[ 34%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/posix_thread.c.o
[ 37%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/glx_context.c.o
[ 40%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/egl_context.c.o
[ 42%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/osmesa_context.c.o
[ 45%] Building C object third-party/glfw-3.3.1/src/CMakeFiles/glfw.dir/linux_joystick.c.o
[ 48%] Linking C static library libglfw3.a
[ 48%] Built target glfw
[ 51%] Generating bin/shaders/gltf-viewer/normals.fs.glsl
[ 54%] Generating bin/shaders/gltf-viewer/forward.vs.glsl
[ 57%] Generating bin/shaders/gltf-viewer/magenta.fs.glsl
Scanning dependencies of target gltf-viewer
[ 60%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/ViewerApplication.cpp.o
[ 62%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/main.cpp.o
[ 65%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/tiny_gltf_impl.cpp.o
[ 68%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/cameras.cpp.o
[ 71%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/gl_debug_output.cpp.o
[ 74%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/gltf.cpp.o
[ 77%] Building CXX object CMakeFiles/gltf-viewer.dir/apps/gltf-viewer/utils/images.cpp.o
[ 80%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui.cpp.o
[ 82%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_demo.cpp.o
[ 85%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_draw.cpp.o
[ 88%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/imgui_widgets.cpp.o
[ 91%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/examples/imgui_impl_opengl3.cpp.o
[ 94%] Building CXX object CMakeFiles/gltf-viewer.dir/third-party/imgui-1.74/examples/imgui_impl_glfw.cpp.o
[ 97%] Building C object CMakeFiles/gltf-viewer.dir/third-party/glad/src/glad.c.o
[100%] Linking CXX executable bin/gltf-viewer
[100%] Built target gltf-viewer

23:43:44 /shared/qcoumes/Courses/M2/AdvancedOpenGL/gltf-viewer-tutorial/cmake-build-debug (clang) $ ./bin/gltf-viewer info
OpenGL Version 4.4
```
